### PR TITLE
Update for version 1.13 and various fixes

### DIFF
--- a/1.12/alpine/3.6/Dockerfile
+++ b/1.12/alpine/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/boost:alpine3.6
+FROM quay.io/westonsteimel/boost:alpine3.6
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.12

--- a/1.12/alpine/3.6/Dockerfile
+++ b/1.12/alpine/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM quay.io/boost:alpine3.6
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.12
@@ -15,8 +15,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     libtool \
     curl \
     tar \
-    boost-dev \
-    && curl -sL --retry 3 http://downloads.sourceforge.net/project/quantlib/QuantLib/${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
+    && curl -sL --retry 3 https://github.com/lballabio/QuantLib/releases/download/QuantLib-v${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \

--- a/1.12/alpine/3.6/Dockerfile
+++ b/1.12/alpine/3.6/Dockerfile
@@ -6,7 +6,7 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
-RUN apk --no-cache add stdlibc++
+RUN apk --no-cache add libstdc++
 
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \

--- a/1.12/alpine/3.6/Dockerfile
+++ b/1.12/alpine/3.6/Dockerfile
@@ -6,6 +6,8 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
+RUN apk --no-cache add stdlibc++
+
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \
     linux-headers \
@@ -19,7 +21,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \
-    && ./configure  --disable-benchmark CXXFLAGS=-O3 \
+    && ./configure --disable-static --disable-benchmark CXXFLAGS=-O3 \
     && make -j ${CONCURRENT_PROCESSES} && make install && ldconfig ./ \
     && cd .. && rm -rf ${QUANTLIB_DIR} \
     && apk del .build-dependencies \

--- a/1.12/alpine/3.7/Dockerfile
+++ b/1.12/alpine/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/boost:alpine3.7
+FROM quay.io/westonsteimel/boost:alpine3.7
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.12

--- a/1.12/alpine/3.7/Dockerfile
+++ b/1.12/alpine/3.7/Dockerfile
@@ -6,7 +6,7 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
-RUN apk --no-cache add stdlibc++
+RUN apk --no-cache add libstdc++
 
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \

--- a/1.12/alpine/3.7/Dockerfile
+++ b/1.12/alpine/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM quay.io/boost:alpine3.7
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.12
@@ -15,8 +15,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     libtool \
     curl \
     tar \
-    boost-dev \
-    && curl -sL --retry 3 http://downloads.sourceforge.net/project/quantlib/QuantLib/${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
+    && curl -sL --retry 3 https://github.com/lballabio/QuantLib/releases/download/QuantLib-v${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \

--- a/1.12/alpine/3.7/Dockerfile
+++ b/1.12/alpine/3.7/Dockerfile
@@ -6,6 +6,8 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
+RUN apk --no-cache add stdlibc++
+
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \
     linux-headers \
@@ -19,7 +21,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \
-    && ./configure  --disable-benchmark CXXFLAGS=-O3 \
+    && ./configure --disable-static --disable-benchmark CXXFLAGS=-O3 \
     && make -j ${CONCURRENT_PROCESSES} && make install && ldconfig ./ \
     && cd .. && rm -rf ${QUANTLIB_DIR} \
     && apk del .build-dependencies \

--- a/1.13/alpine/3.6/Dockerfile
+++ b/1.13/alpine/3.6/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.4
+FROM quay.io/boost:alpine3.6
 LABEL description="QuantLib on Alpine Linux."
 
-ARG QUANTLIB_VERSION=1.12
+ARG QUANTLIB_VERSION=1.13
 ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
@@ -15,8 +15,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     libtool \
     curl \
     tar \
-    boost-dev \
-    && curl -sL --retry 3 http://downloads.sourceforge.net/project/quantlib/QuantLib/${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
+    && curl -sL --retry 3 https://github.com/lballabio/QuantLib/releases/download/QuantLib-v${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \

--- a/1.13/alpine/3.6/Dockerfile
+++ b/1.13/alpine/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/boost:alpine3.6
+FROM quay.io/westonsteimel/boost:alpine3.6
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.13

--- a/1.13/alpine/3.6/Dockerfile
+++ b/1.13/alpine/3.6/Dockerfile
@@ -6,7 +6,7 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
-RUN apk --no-cache add stdlibc++
+RUN apk --no-cache add libstdc++
 
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \

--- a/1.13/alpine/3.6/Dockerfile
+++ b/1.13/alpine/3.6/Dockerfile
@@ -6,6 +6,8 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
+RUN apk --no-cache add stdlibc++
+
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \
     linux-headers \
@@ -19,7 +21,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \
-    && ./configure  --disable-benchmark CXXFLAGS=-O3 \
+    && ./configure --disable-static --disable-benchmark CXXFLAGS=-O3 \
     && make -j ${CONCURRENT_PROCESSES} && make install && ldconfig ./ \
     && cd .. && rm -rf ${QUANTLIB_DIR} \
     && apk del .build-dependencies \

--- a/1.13/alpine/3.7/Dockerfile
+++ b/1.13/alpine/3.7/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.5
+FROM quay.io/boost:alpine3.7
 LABEL description="QuantLib on Alpine Linux."
 
-ARG QUANTLIB_VERSION=1.12
+ARG QUANTLIB_VERSION=1.13
 ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
@@ -15,8 +15,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     libtool \
     curl \
     tar \
-    boost-dev \
-    && curl -sL --retry 3 http://downloads.sourceforge.net/project/quantlib/QuantLib/${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
+    && curl -sL --retry 3 https://github.com/lballabio/QuantLib/releases/download/QuantLib-v${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \

--- a/1.13/alpine/3.7/Dockerfile
+++ b/1.13/alpine/3.7/Dockerfile
@@ -6,7 +6,7 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
-RUN apk --no-cache add stdlibc++
+RUN apk --no-cache add libstdc++
 
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \

--- a/1.13/alpine/3.7/Dockerfile
+++ b/1.13/alpine/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/boost:alpine3.7
+FROM quay.io/westonsteimel/boost:alpine3.7
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=1.13

--- a/1.13/alpine/3.7/Dockerfile
+++ b/1.13/alpine/3.7/Dockerfile
@@ -6,6 +6,8 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
+RUN apk --no-cache add stdlibc++
+
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \
     linux-headers \
@@ -19,7 +21,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \
-    && ./configure  --disable-benchmark CXXFLAGS=-O3 \
+    && ./configure --disable-static --disable-benchmark CXXFLAGS=-O3 \
     && make -j ${CONCURRENT_PROCESSES} && make install && ldconfig ./ \
     && cd .. && rm -rf ${QUANTLIB_DIR} \
     && apk del .build-dependencies \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM alpine:%%TAG%%
+FROM quay.io/boost:%%TAG%%
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=%%QUANTLIB_VERSION%%
@@ -15,8 +15,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     libtool \
     curl \
     tar \
-    boost-dev \
-    && curl -sL --retry 3 http://downloads.sourceforge.net/project/quantlib/QuantLib/${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
+    && curl -sL --retry 3 https://github.com/lballabio/QuantLib/releases/download/QuantLib-v${QUANTLIB_VERSION}/QuantLib-${QUANTLIB_VERSION}.tar.gz | \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -6,7 +6,7 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
-RUN apk --no-cache add stdlibc++
+RUN apk --no-cache add libstdc++
 
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -6,6 +6,8 @@ ARG CONCURRENT_PROCESSES
 ARG QUANTLIB_DIR=QuantLib
 ENV QUANTLIB_VERSION ${QUANTLIB_VERSION}
 
+RUN apk --no-cache add stdlibc++
+
 RUN mkdir -p ${QUANTLIB_DIR} \
     && apk --no-cache add --virtual .build-dependencies \
     linux-headers \
@@ -19,7 +21,7 @@ RUN mkdir -p ${QUANTLIB_DIR} \
     tar -xz --strip 1 -C ${QUANTLIB_DIR}/ \
     && cd ${QUANTLIB_DIR} \
     && sh autogen.sh \
-    && ./configure  --disable-benchmark CXXFLAGS=-O3 \
+    && ./configure --disable-static --disable-benchmark CXXFLAGS=-O3 \
     && make -j ${CONCURRENT_PROCESSES} && make install && ldconfig ./ \
     && cd .. && rm -rf ${QUANTLIB_DIR} \
     && apk del .build-dependencies \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM quay.io/boost:%%TAG%%
+FROM quay.io/westonsteimel/boost:%%TAG%%
 LABEL description="QuantLib on Alpine Linux."
 
 ARG QUANTLIB_VERSION=%%QUANTLIB_VERSION%%

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # QuantLib in Docker
 Dockerized environment with [QuantLib](http://quantlib.org) based on [Alpine Linux](https://alpinelinux.org).
+
+## Pull command
+`docker pull quay.io/westonsteimel/quantlib`

--- a/generate.sh
+++ b/generate.sh
@@ -16,7 +16,7 @@ sed_escape_rhs() {
 	echo "$@" | sed -e 's/[\/&]/\\&/g' | sed -e ':a;N;$!ba;s/\n/\\n/g'
 }
 
-alpine_versions=(3.4 3.5 3.6 3.7)
+alpine_versions=(3.6 3.7)
 
 for version in "${ql_versions[@]}"; do
     echo "Generating Dockerfiles for QuantLib version ${version}."
@@ -25,7 +25,7 @@ for version in "${ql_versions[@]}"; do
 	mkdir -p ${version}/alpine/${alpine_version}
         
 	sed -r \
-	    -e 's!%%TAG%%!'"${alpine_version}"'!g' \
+	    -e 's!%%TAG%%!'"alpine${alpine_version}"'!g' \
 	    -e 's!%%QUANTLIB_VERSION%%!'"${version}"'!g' \
             "Dockerfile-alpine.template" > "${version}/alpine/${alpine_version}/Dockerfile"
 	echo "Generated ${version}/alpine/${alpine_version}/Dockerfile"


### PR DESCRIPTION
- Remove older versions of Alpine and QL
- Switch to quay.io
- Switch back to using my boost base image instead of the alpine package
- Install libstdc++ 